### PR TITLE
feat: add learning html pfeat: add learning html pageage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1132 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Agent Learning Hub</title>
+<style>
+/* ===== CSS Variables ===== */
+:root {
+  --bg: #ffffff;
+  --bg-secondary: #f7f7f5;
+  --bg-card: #ffffff;
+  --bg-hover: #f0f0ed;
+  --bg-sidebar: #fbfbfa;
+  --text: #1a1a1a;
+  --text-secondary: #6b6b6b;
+  --text-tertiary: #9b9b9b;
+  --border: #e6e6e4;
+  --accent: #2383e2;
+  --accent-hover: #1a6bc1;
+  --accent-light: #e8f2fb;
+  --success: #0f7b3a;
+  --success-bg: #e8f5ee;
+  --warning: #d97706;
+  --warning-bg: #fef7ed;
+  --shadow: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
+  --radius: 8px;
+  --radius-sm: 4px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
+  --sidebar-width: 240px;
+  --topbar-height: 52px;
+}
+[data-theme="dark"] {
+  --bg: #191919;
+  --bg-secondary: #1f1f1f;
+  --bg-card: #252525;
+  --bg-hover: #2a2a2a;
+  --bg-sidebar: #1c1c1c;
+  --text: #e4e4e4;
+  --text-secondary: #9b9b9b;
+  --text-tertiary: #6b6b6b;
+  --border: #333333;
+  --accent: #4498e0;
+  --accent-hover: #5dabf0;
+  --accent-light: #1a2d40;
+  --success: #3cb371;
+  --success-bg: #1a2f24;
+  --warning: #e6a817;
+  --warning-bg: #2f2616;
+  --shadow: 0 1px 3px rgba(0,0,0,0.2);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+/* ===== Reset ===== */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+body{font-family:var(--font);background:var(--bg);color:var(--text);line-height:1.6;min-height:100vh}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+ul,ol{padding-left:1.5em}
+code{font-family:var(--font-mono);font-size:0.88em;background:var(--bg-secondary);padding:2px 6px;border-radius:var(--radius-sm);border:1px solid var(--border)}
+table{width:100%;border-collapse:collapse;font-size:0.92em}
+th,td{text-align:left;padding:10px 14px;border-bottom:1px solid var(--border)}
+th{font-weight:600;color:var(--text-secondary);font-size:0.85em;text-transform:uppercase;letter-spacing:0.04em;background:var(--bg-secondary);position:sticky;top:0;z-index:1}
+tr:hover td{background:var(--bg-hover)}
+td:first-child,th:first-child{border-left:1px solid var(--border)}
+td:last-child,th:last-child{border-right:1px solid var(--border)}
+thead tr:first-child th:first-child{border-top-left-radius:var(--radius)}
+thead tr:first-child th:last-child{border-top-right-radius:var(--radius)}
+table{border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
+
+/* ===== Layout ===== */
+.layout{display:flex;min-height:100vh}
+.topbar{position:fixed;top:0;left:0;right:0;height:var(--topbar-height);background:var(--bg);border-bottom:1px solid var(--border);display:flex;align-items:center;padding:0 20px;z-index:100;gap:0}
+.topbar-left{display:flex;align-items:center;gap:12px;min-width:var(--sidebar-width);padding-right:16px}
+.topbar-logo{font-weight:700;font-size:1.1em;color:var(--text);white-space:nowrap}
+.topbar-center{flex:1;display:flex;align-items:center;justify-content:center;gap:4px}
+.topbar-right{display:flex;align-items:center;gap:8px;min-width:160px;justify-content:flex-end}
+.tab-btn{padding:8px 18px;border:none;background:none;color:var(--text-secondary);font-size:0.92em;font-family:var(--font);cursor:pointer;border-radius:var(--radius-sm);transition:all 0.15s;font-weight:500;white-space:nowrap}
+.tab-btn:hover{background:var(--bg-hover);color:var(--text)}
+.tab-btn.active{background:var(--accent-light);color:var(--accent);font-weight:600}
+.search-wrap{position:relative}
+.search-input{padding:6px 12px 6px 34px;border:1px solid var(--border);border-radius:20px;font-size:0.88em;font-family:var(--font);background:var(--bg-secondary);color:var(--text);width:200px;outline:none;transition:all 0.2s}
+.search-input:focus{border-color:var(--accent);width:260px;box-shadow:0 0 0 3px rgba(35,131,226,0.12)}
+.search-icon{position:absolute;left:10px;top:50%;transform:translateY(-50%);color:var(--text-tertiary);font-size:0.85em;pointer-events:none}
+.theme-btn{width:34px;height:34px;border:1px solid var(--border);border-radius:50%;background:var(--bg-card);cursor:pointer;font-size:1.1em;display:flex;align-items:center;justify-content:center;transition:all 0.15s}
+.theme-btn:hover{background:var(--bg-hover);border-color:var(--accent)}
+
+.sidebar{position:fixed;top:var(--topbar-height);left:0;bottom:0;width:var(--sidebar-width);background:var(--bg-sidebar);border-right:1px solid var(--border);overflow-y:auto;padding:16px 12px;z-index:90}
+.sidebar-label{font-size:0.75em;text-transform:uppercase;letter-spacing:0.06em;color:var(--text-tertiary);padding:8px 8px 6px;font-weight:600}
+.sidebar-link{display:block;padding:7px 10px;border-radius:var(--radius-sm);color:var(--text-secondary);font-size:0.9em;cursor:pointer;transition:all 0.12s;border:none;background:none;width:100%;text-align:left;font-family:var(--font)}
+.sidebar-link:hover{background:var(--bg-hover);color:var(--text)}
+.sidebar-link.active{background:var(--accent-light);color:var(--accent);font-weight:600}
+.sidebar-badge{float:right;font-size:0.78em;background:var(--bg-secondary);padding:1px 7px;border-radius:10px;color:var(--text-tertiary)}
+.sidebar-link.active .sidebar-badge{background:var(--accent);color:#fff}
+
+.main{flex:1;margin-left:var(--sidebar-width);margin-top:var(--topbar-height);padding:28px 36px 80px;min-width:0;display:flex;justify-content:center}
+.main-inner{max-width:860px;width:100%}
+.section{display:none}
+.section.active{display:block}
+.section-title{font-size:1.6em;font-weight:700;margin-bottom:8px;color:var(--text)}
+.section-desc{color:var(--text-secondary);margin-bottom:24px;font-size:0.95em;line-height:1.7}
+
+/* ===== Progress ===== */
+.progress-bar-wrap{background:var(--bg-secondary);border-radius:20px;height:8px;overflow:hidden;margin:12px 0 24px}
+.progress-bar-fill{height:100%;background:linear-gradient(90deg, var(--accent), #5db8fe);border-radius:20px;transition:width 0.35s ease}
+.progress-stats{display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;font-size:0.9em;color:var(--text-secondary)}
+.progress-stats strong{color:var(--text);font-size:1.2em}
+
+/* ===== Stage Card ===== */
+.stage-card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:20px 24px;margin-bottom:16px;box-shadow:var(--shadow);transition:box-shadow 0.2s}
+.stage-card:hover{box-shadow:var(--shadow-md)}
+.stage-card-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
+.stage-card-title{font-weight:700;font-size:1.1em;color:var(--text)}
+.stage-card-badge{font-size:0.78em;padding:3px 10px;border-radius:12px;font-weight:600}
+.stage-card-badge.green{background:var(--success-bg);color:var(--success)}
+.stage-card-badge.yellow{background:var(--warning-bg);color:var(--warning)}
+.stage-card-badge.neutral{background:var(--bg-secondary);color:var(--text-secondary)}
+.stage-progress{height:4px;background:var(--bg-secondary);border-radius:4px;margin-bottom:16px}
+.stage-progress-fill{height:100%;background:var(--accent);border-radius:4px;transition:width 0.3s}
+
+/* ===== Checklist ===== */
+.check-item{display:flex;align-items:flex-start;gap:10px;padding:8px 10px;border-radius:var(--radius-sm);transition:background 0.12s;cursor:pointer;user-select:none}
+.check-item:hover{background:var(--bg-hover)}
+.check-item.done .check-label{color:var(--text-tertiary);text-decoration:line-through}
+.check-item.done .check-label a{text-decoration:line-through}
+.check-box{flex-shrink:0;width:18px;height:18px;border:2px solid var(--border);border-radius:4px;display:flex;align-items:center;justify-content:center;transition:all 0.15s;margin-top:1px}
+.check-item:hover .check-box{border-color:var(--accent)}
+.check-item.done .check-box{background:var(--success);border-color:var(--success)}
+.check-item.done .check-box::after{content:'✓';color:#fff;font-size:0.7em;font-weight:700}
+.check-label{font-size:0.94em;color:var(--text);flex:1;line-height:1.7}
+.check-label a{color:var(--accent)}
+.sub-content{padding:8px 0 8px 30px;color:var(--text-secondary);font-size:0.9em}
+
+/* ===== Project Ladder ===== */
+.ladder-card{display:flex;align-items:center;gap:16px;padding:14px 18px;background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);margin-bottom:8px;box-shadow:var(--shadow);cursor:pointer;transition:all 0.15s;user-select:none}
+.ladder-card:hover{box-shadow:var(--shadow-md);border-color:var(--accent)}
+.ladder-card.done{opacity:0.6}
+.ladder-card.done .ladder-title{text-decoration:line-through}
+.ladder-num{width:32px;height:32px;border-radius:50%;background:var(--bg-secondary);display:flex;align-items:center;justify-content:center;font-weight:700;font-size:0.9em;flex-shrink:0;color:var(--text-secondary)}
+.ladder-card.done .ladder-num{background:var(--success);color:#fff}
+.ladder-info{flex:1;min-width:0}
+.ladder-title{font-weight:600;font-size:0.96em;color:var(--text)}
+.ladder-desc{font-size:0.84em;color:var(--text-secondary);margin-top:2px}
+.ladder-check{flex-shrink:0}
+
+/* ===== Resource Cards ===== */
+.resource-table-wrap{overflow-x:auto;margin-bottom:24px;background:var(--bg-card);border-radius:var(--radius);box-shadow:var(--shadow)}
+.resource-table-wrap table{border:none}
+.resource-table-wrap td:first-child,.resource-table-wrap th:first-child{border-left:none}
+.resource-table-wrap td:last-child,.resource-table-wrap th:last-child{border-right:none}
+.resource-section-title{font-size:1.15em;font-weight:700;margin:32px 0 12px;color:var(--text)}
+.resource-section-title:first-child{margin-top:0}
+
+/* ===== Info Cards ===== */
+.info-cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:12px;margin-bottom:24px}
+.info-card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:16px 18px;box-shadow:var(--shadow)}
+.info-card-title{font-weight:600;font-size:0.92em;margin-bottom:6px;color:var(--text)}
+.info-card-body{font-size:0.88em;color:var(--text-secondary);line-height:1.6}
+.info-card-body a{color:var(--accent)}
+
+/* ===== Priority Table ===== */
+.priority-grid{display:grid;grid-template-columns:auto 1fr auto;gap:0;border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;margin-bottom:24px;box-shadow:var(--shadow)}
+.priority-grid .pg-row{display:contents}
+.priority-grid .pg-row>div{padding:12px 16px;border-bottom:1px solid var(--border);background:var(--bg-card);display:flex;align-items:center}
+.priority-grid .pg-row:last-child>div{border-bottom:none}
+.pg-priority{font-weight:700;font-size:1.2em;color:var(--accent);justify-content:center!important;min-width:60px}
+.pg-title{font-weight:600;font-size:0.95em}
+.pg-desc{font-size:0.88em;color:var(--text-secondary)}
+
+/* ===== Search Highlight ===== */
+mark{background:rgba(255,200,0,0.35);color:inherit;border-radius:2px;padding:0 2px}
+[data-theme="dark"] mark{background:rgba(255,200,0,0.25)}
+
+/* ===== No Results ===== */
+.no-results{display:none;text-align:center;padding:60px 20px;color:var(--text-secondary)}
+.no-results.show{display:block}
+.no-results-icon{font-size:3em;margin-bottom:12px}
+
+/* ===== Scrollbar ===== */
+::-webkit-scrollbar{width:6px;height:6px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
+::-webkit-scrollbar-thumb:hover{background:var(--text-tertiary)}
+
+/* ===== Mobile ===== */
+@media(max-width:768px){
+  .sidebar{display:none;position:fixed;top:var(--topbar-height);left:0;bottom:0;width:100%;z-index:200;padding-top:8px}
+  .sidebar.open{display:block}
+  .sidebar-overlay{display:none;position:fixed;inset:0;top:var(--topbar-height);background:rgba(0,0,0,0.4);z-index:89}
+  .sidebar-overlay.open{display:block}
+  .main{margin-left:0;padding:16px 16px 60px}.main-inner{max-width:100%}
+  .topbar-left{min-width:auto}
+  .topbar-center{display:none}
+  .topbar-center.mobile-search{display:flex;position:fixed;top:var(--topbar-height);left:0;right:0;padding:10px 16px;background:var(--bg);border-bottom:1px solid var(--border);z-index:85}
+  .search-input{width:160px}
+  .search-input:focus{width:180px}
+  .mobile-menu-btn{width:34px;height:34px;border:1px solid var(--border);border-radius:6px;background:var(--bg-card);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:1.2em}
+  table,.resource-table-wrap{font-size:0.8em}
+  th,td{padding:8px 10px}
+  .info-cards{grid-template-columns:1fr}
+  .priority-grid{grid-template-columns:1fr}
+  .priority-grid .pg-row{display:flex;flex-direction:column;border-bottom:1px solid var(--border)}
+  .priority-grid .pg-row:last-child{border-bottom:none}
+  .pg-priority{align-self:flex-start}
+}
+
+@media(max-width:480px){
+  .topbar-right{gap:4px}
+  .search-input{width:120px}
+  .search-input:focus{width:150px}
+  .main{padding:12px 10px 60px}
+  .stage-card{padding:14px 16px}
+}
+/* ===== Note Editor ===== */
+.note-editor{margin-top:14px;border:1px solid var(--border);border-radius:var(--radius);overflow:hidden}
+.note-preview{padding:16px 18px;background:var(--bg);cursor:pointer;transition:background 0.12s;font-size:0.93em;line-height:1.7;min-height:48px;display:flex;align-items:center;justify-content:space-between}
+.note-preview:hover{background:var(--bg-hover)}
+.note-preview.has-content{align-items:flex-start}
+.note-empty{color:var(--text-tertiary);font-style:italic;flex:1}
+.note-title{font-weight:600;font-size:0.82em;color:var(--text-secondary);margin-bottom:6px}
+.note-body{color:var(--text);flex:1}
+.note-body h1{font-size:1.35em;margin:12px 0 6px;padding-bottom:4px;border-bottom:1px solid var(--border)}.note-body h2{font-size:1.15em;margin:10px 0 4px;font-weight:700}.note-body h3{font-size:1.02em;margin:8px 0 4px;font-weight:700;color:var(--text-secondary)}
+.note-body p{margin:4px 0}
+.note-body code{font-size:0.85em}
+.note-body pre{background:var(--bg-secondary);padding:10px 14px;border-radius:var(--radius-sm);overflow-x:auto;font-size:0.85em;margin:6px 0}
+.note-body blockquote{border-left:3px solid var(--accent);padding-left:12px;color:var(--text-secondary);margin:6px 0}
+.note-body ul,.note-body ol{padding-left:1.2em;margin:4px 0}
+.note-body hr{border:none;border-top:1px solid var(--border);margin:12px 0}
+.note-btn{flex-shrink:0;padding:5px 12px;border:1px solid var(--border);border-radius:var(--radius-sm);background:var(--bg-card);color:var(--text-secondary);font-size:0.82em;cursor:pointer;font-family:var(--font);transition:all 0.12s;margin-left:12px}
+.note-btn:hover{background:var(--bg-hover);color:var(--text);border-color:var(--accent)}
+.note-btn.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
+.note-btn.primary:hover{background:var(--accent-hover)}
+.note-editor-area{padding:12px 16px 14px}
+.note-textarea{width:100%;min-height:160px;padding:12px;border:1px solid var(--border);border-radius:var(--radius-sm);font-family:var(--font-mono);font-size:0.9em;line-height:1.7;resize:vertical;background:var(--bg);color:var(--text);outline:none}
+.note-textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px rgba(35,131,226,0.1)}
+.note-toolbar{display:flex;gap:8px;margin-top:10px;align-items:center}
+.note-hint{font-size:0.78em;color:var(--text-tertiary);flex:1}
+.markdown-preview-toggle{font-size:0.82em;color:var(--accent);cursor:pointer;user-select:none}
+.markdown-preview-toggle:hover{text-decoration:underline}
+.note-preview-pane{padding:16px 18px;background:var(--bg-secondary);border-bottom:1px solid var(--border);font-size:0.93em;line-height:1.7;display:none}
+.note-preview-pane.open{display:block}
+.note-preview-pane h1{font-size:1.35em;margin:12px 0 6px;padding-bottom:4px;border-bottom:1px solid var(--border)}.note-preview-pane h2{font-size:1.15em;margin:10px 0 4px;font-weight:700}.note-preview-pane h3{font-size:1.02em;margin:8px 0 4px;font-weight:700;color:var(--text-secondary)}
+.note-preview-pane p{margin:4px 0}
+.note-preview-pane code{font-size:0.85em}
+.note-preview-pane pre{background:var(--bg);padding:10px 14px;border-radius:var(--radius-sm);overflow-x:auto;font-size:0.85em;margin:6px 0}
+.note-preview-pane blockquote{border-left:3px solid var(--accent);padding-left:12px;color:var(--text-secondary);margin:6px 0}
+.note-preview-pane ul,.note-preview-pane ol{padding-left:1.2em;margin:4px 0}
+.note-preview-pane hr{border:none;border-top:1px solid var(--border);margin:12px 0}
+</style>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+
+<div class="layout">
+  <!-- Topbar -->
+  <header class="topbar">
+    <div class="topbar-left">
+      <button class="mobile-menu-btn" onclick="toggleSidebar()" aria-label="Menu" style="display:none">☰</button>
+      <span class="topbar-logo">🤖 Agent Learning Hub</span>
+    </div>
+    <nav class="topbar-center" id="tabNav">
+      <button class="tab-btn active" data-tab="learn">学习路线</button>
+      <button class="tab-btn" data-tab="ladder">项目阶梯</button>
+      <button class="tab-btn" data-tab="resources">精选资源</button>
+    </nav>
+    <div class="topbar-right">
+      <div class="search-wrap">
+        <span class="search-icon">🔍</span>
+        <input type="text" class="search-input" id="searchInput" placeholder="搜索..." oninput="doSearch()">
+      </div>
+      <button class="theme-btn" onclick="toggleTheme()" id="themeBtn" aria-label="Toggle theme" title="切换暗色/亮色模式">🌙</button>
+    </div>
+  </header>
+
+  <!-- Sidebar -->
+  <aside class="sidebar" id="sidebar">
+    <div id="sidebarContent"></div>
+  </aside>
+  <div class="sidebar-overlay" id="sidebarOverlay" onclick="closeSidebar()"></div>
+
+  <!-- Main Content -->
+  <main class="main" id="mainContent"></main>
+</div>
+
+<script>
+// ===== Data =====
+const learningData = {
+  priorityTable: [
+    { priority:1, learn:'Claude Code / Codex-style coding agents', why:'真实代码库、shell、文件编辑、测试、权限、上下文压缩，是最好的 agent 工程样本。' },
+    { priority:2, learn:'Agent harness engineering', why:'agent 的能力很大一部分来自 harness：工具协议、权限、状态、反馈、回放、CI、评测。' },
+    { priority:3, learn:'OpenClaw / Hermes-style personal agents', why:'长运行、本地优先、跨应用、记忆、skills、消息入口，更像"个人操作系统"。' },
+    { priority:4, learn:'Skills / MCP / A2A / ACP', why:'skills 负责能力复用，MCP 连接工具，A2A 连接 agent，ACP 连接宿主应用。' },
+    { priority:5, learn:'Evaluation and safety', why:'没有 eval、trace、权限边界的 agent 只能算 demo。' }
+  ],
+  stages: [
+    {
+      id:'stage0', title:'Stage 0: 理解 Agent 是什么',
+      items:[
+        '区分 chatbot、workflow、agent、multi-agent。',
+        '理解 agent 的基本循环：observe → think → act → observe。',
+        '明白什么时候不该用 agent：任务可预测、流程稳定、普通脚本能解决时，agent 反而增加不确定性。',
+        '读完 <a href="https://www.anthropic.com/engineering/building-effective-agents" target="_blank">Anthropic: Building effective agents</a>。',
+        '读完 <a href="https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/" target="_blank">OpenAI: A practical guide to building agents</a>。'
+      ],
+      reading: '',
+      projects: '',
+      output: '写一页短笔记，回答「我的场景为什么需要 agent，而不是普通 workflow？」'
+    },
+    {
+      id:'stage1', title:'Stage 1: 构建最小 Agent Loop',
+      items:[
+        '会用一个 LLM API 完成普通对话。',
+        '会让模型输出结构化 JSON。',
+        '会定义一个工具函数，例如 search、calculator、read_file。',
+        '会解析模型的 tool call / function call。',
+        '会执行工具，并把工具结果喂回模型。',
+        '会给 agent loop 加最大步数、超时和错误处理。'
+      ],
+      reading: `<table><thead><tr><th>Resource</th></tr></thead><tbody>
+        <tr><td><a href="https://platform.openai.com/docs/guides/function-calling" target="_blank">OpenAI Function Calling</a></td></tr>
+        <tr><td><a href="https://ai.google.dev/gemini-api/docs/function-calling" target="_blank">Gemini API Function Calling</a></td></tr>
+        <tr><td><a href="https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview" target="_blank">Claude Tool Use</a></td></tr>
+      </tbody></table>`,
+      projects: '',
+      output: '一个 50-150 行的最小 agent，可以选择工具、执行工具、返回最终答案。'
+    },
+    {
+      id:'stage2', title:'Stage 2: 学习工具调用、RAG 与记忆',
+      items:[
+        '会做检索增强生成：chunk、embed、retrieve、answer with citations。',
+        '会把搜索、数据库、文件、浏览器、代码执行接成工具。',
+        '会区分短期上下文、会话记忆、长期记忆。',
+        '会处理工具失败、空结果、重复调用、幻觉引用。',
+        '会让 agent 在回答里给出来源或证据。'
+      ],
+      reading: `<table><thead><tr><th>Resource</th></tr></thead><tbody>
+        <tr><td><a href="https://docs.llamaindex.ai/en/stable/use_cases/agents/" target="_blank">LlamaIndex Agents</a></td></tr>
+        <tr><td><a href="https://docs.langchain.com/" target="_blank">LangChain Docs</a></td></tr>
+        <tr><td><a href="https://ai.google.dev/gemini-api/docs/code-execution" target="_blank">Gemini API Code Execution</a></td></tr>
+        <tr><td><a href="https://modelcontextprotocol.io/" target="_blank">Model Context Protocol</a></td></tr>
+      </tbody></table>`,
+      projects: '<table><thead><tr><th>Project</th><th>Why It Fits Stage 2</th></tr></thead><tbody>' + [
+        ['<a href="https://github.com/assafelovic/gpt-researcher" target="_blank">GPT Researcher</a>','最接近"资料研究助手"的成品：搜索、抓取、筛选、引用、生成长报告。'],
+        ['<a href="https://github.com/langchain-ai/open_deep_research" target="_blank">Open Deep Research</a>','LangGraph 写的 deep research 示例，适合学多轮搜索、状态管理和引用输出。'],
+        ['<a href="https://github.com/stanford-oval/storm" target="_blank">STORM</a>','Stanford OVAL 的研究写作系统，适合学 outline、question asking、多视角资料综合。'],
+        ['<a href="https://github.com/khoj-ai/khoj" target="_blank">Khoj</a>','个人 second brain，适合学本地文档、网页、语义搜索和长期记忆。'],
+        ['<a href="https://github.com/onyx-dot-app/onyx" target="_blank">Onyx</a>','企业级 RAG/search assistant，适合学 connectors、hybrid search、权限和生产化。'],
+        ['<a href="https://github.com/Mintplex-Labs/anything-llm" target="_blank">AnythingLLM</a>','本地 RAG + agents 产品，适合初学者快速理解完整应用形态。'],
+        ['<a href="https://github.com/infiniflow/ragflow" target="_blank">RAGFlow</a>','文档理解型 RAG 引擎，适合学 ingestion、chunking、retrieval、grounded answer。'],
+        ['<a href="https://github.com/mem0ai/mem0" target="_blank">mem0</a>','记忆层组件，适合学如何给 agent 加长期 memory。'],
+        ['<a href="https://github.com/letta-ai/letta" target="_blank">Letta</a>','面向 stateful agents 的 memory/context 平台，适合学上下文管理。']
+      ].map(r=>`<tr><td>${r[0]}</td><td>${r[1]}</td></tr>`).join('')+'</tbody></table>',
+      output: '一个资料研究助手，输入主题后自动搜索、筛选、总结并输出引用链接。'
+    },
+    {
+      id:'stage3', title:'Stage 3: 深入研究一个现代 Agent Harness',
+      items:[
+        '读懂一个 agent harness 的目录结构。',
+        '找出它的 agent loop、tool registry、permission gate、session store、context compaction。',
+        '跑通它的最小示例，并加一个你自己的工具。',
+        '观察一次完整 trace，解释每一步为什么发生。',
+        '把同一个任务分别用「裸 agent loop」和「harness」实现，对比差异。'
+      ],
+      reading: `<p style="margin-bottom:12px">先选一个现代 agent 系统学深。这里的重点不是"框架 API 怎么调"，而是它如何组织工具、上下文、权限、状态、日志、子任务和反馈。</p>
+      <table><thead><tr><th>System</th><th>Best For</th><th>Learn This If You Want To</th></tr></thead><tbody>` + [
+        ['<a href="https://code.claude.com/docs/en/overview" target="_blank">Claude Code Docs</a>','Coding agent product','学真实 coding agent 的 CLI、工具、权限、hooks、subagents、MCP。'],
+        ['<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">learn-claude-code</a>','From-scratch agent harness','从 0 到 1 复刻 Claude Code-like harness。'],
+        ['<a href="https://github.com/shareAI-lab/claw0" target="_blank">claw0</a>','From-scratch OpenClaw gateway','从 agent loop 一路构建 session、channel、gateway、memory、heartbeat、delivery、resilience、concurrency。'],
+        ['<a href="https://github.com/datawhalechina/hello-agents" target="_blank">hello-agents</a>','Chinese agent tutorial','从零开始构建智能体，适合系统补 Agent 原理与实践。'],
+        ['<a href="https://github.com/openclaw/openclaw" target="_blank">OpenClaw</a>','Local-first personal agent','学本地长运行 agent、skills、消息入口、系统工具和安全边界。'],
+        ['<a href="https://github.com/NousResearch/hermes-agent" target="_blank">Hermes Agent</a>','Self-hosted growing agent','学长期记忆、skills、toolsets、多平台消息网关和迁移能力。'],
+        ['<a href="https://github.com/ttguy0707/CyberClaw" target="_blank">CyberClaw</a>','Transparent agent architecture','学全行为审计、两段式安全调用、双水位记忆和心跳任务。'],
+        ['<a href="https://langchain-ai.github.io/langgraph/" target="_blank">LangGraph</a>','Stateful graph orchestration','学状态图、可恢复执行和可控编排。']
+      ].map(r=>`<tr><td>${r[0]}</td><td>${r[1]}</td><td>${r[2]}</td></tr>`).join('')+'</tbody></table>',
+      projects: '',
+      output: '一个可调试的 agent harness demo，包含 README、运行步骤、示例输入输出和失败记录。'
+    },
+    {
+      id:'stage4', title:'Stage 4: 多 Agent 是协调问题，不是魔法',
+      items:[
+        '理解 planner / executor / reviewer / critic / router 等常见角色。',
+        '学会用 supervisor 或 graph 管理多 agent，而不是让 agent 随便聊天。',
+        '会定义每个 agent 的职责边界、输入输出 schema、停止条件。',
+        '会处理循环、争论、任务漂移、上下文膨胀。',
+        '会判断什么时候单 agent 更好。'
+      ],
+      reading: `<table><thead><tr><th>Resource</th></tr></thead><tbody>
+        <tr><td><a href="https://code.claude.com/docs/en/sub-agents" target="_blank">Claude Code Subagents</a></td></tr>
+        <tr><td><a href="https://code.claude.com/docs/en/hooks" target="_blank">Claude Code Hooks</a></td></tr>
+        <tr><td><a href="https://google.github.io/adk-docs/" target="_blank">Google Agent Development Kit</a></td></tr>
+        <tr><td><a href="https://google-a2a.github.io/A2A/specification/" target="_blank">Agent2Agent Protocol</a></td></tr>
+        <tr><td><a href="https://agentclientprotocol.com/" target="_blank">Agent Client Protocol</a></td></tr>
+      </tbody></table>`,
+      projects: '',
+      output: '一个小型多 agent 系统，例如 research → write → review → revise。'
+    },
+    {
+      id:'stage5', title:'Stage 5: 学习 Skills、协议与能力打包',
+      items:[
+        '理解 Skill 和 Tool 的区别：tool 是可调用接口，skill 是可复用流程知识。',
+        '理解 Skill 和 Prompt 的区别：prompt 通常是一次性指令，skill 是可发现、可版本化、可分发的能力包。',
+        '理解 Skill 和 MCP 的区别：MCP 接入外部工具/数据源，skill 告诉 agent 如何完成一类任务。',
+        '阅读 Claude Code Skills 的文件结构和触发机制。',
+        '阅读 OpenClaw Skills 的加载、作用域和安全边界。',
+        '写一个最小 <code>SKILL.md</code>，包含 name、description、何时使用、步骤、验收标准。',
+        '给 skill 加一个脚本或模板文件，并说明 agent 什么时候才需要加载它。',
+        '给 skill 写一个 smoke test，验证它是否真的提升任务成功率。'
+      ],
+      reading: `<table><thead><tr><th>Resource</th></tr></thead><tbody>
+        <tr><td><a href="https://code.claude.com/docs/en/skills" target="_blank">Claude Code Skills</a></td></tr>
+        <tr><td><a href="https://docs.claude.com/en/docs/agents-and-tools/agent-skills" target="_blank">Claude Agent Skills</a></td></tr>
+        <tr><td><a href="https://code.claude.com/docs/en/agent-sdk/skills" target="_blank">Claude Code Agent SDK Skills</a></td></tr>
+        <tr><td><a href="https://github.com/openclaw/openclaw/blob/main/docs/tools/skills.md" target="_blank">OpenClaw Skills</a></td></tr>
+        <tr><td><a href="https://modelcontextprotocol.io/" target="_blank">Model Context Protocol</a></td></tr>
+        <tr><td><a href="https://google-a2a.github.io/A2A/specification/" target="_blank">Agent2Agent Protocol</a></td></tr>
+        <tr><td><a href="https://agentclientprotocol.com/" target="_blank">Agent Client Protocol</a></td></tr>
+      </tbody></table>`,
+      projects: '',
+      output: '一个可复用 skill，例如 code-review、research-report、migration-helper、pdf-extraction 或 release-note-writer。'
+    },
+    {
+      id:'stage6', title:'Stage 6: 浏览器与 Computer-Use Agent',
+      items:[
+        '理解 browser agent 和普通 API tool 的区别。',
+        '会用 Playwright 或 browser-use 做网页观察和点击。',
+        '会给浏览器操作加安全限制：不登录敏感账号、不越权、不绕过平台规则。',
+        '会处理页面变化、弹窗、加载失败、元素定位失败。',
+        '会记录截图、DOM、动作日志，方便复盘。'
+      ],
+      reading: `<table><thead><tr><th>Resource</th></tr></thead><tbody>
+        <tr><td><a href="https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool" target="_blank">Claude Computer Use</a></td></tr>
+        <tr><td><a href="https://github.com/browser-use/browser-use" target="_blank">browser-use</a></td></tr>
+        <tr><td><a href="https://arxiv.org/abs/2307.13854" target="_blank">WebArena</a></td></tr>
+        <tr><td><a href="https://arxiv.org/abs/2401.13649" target="_blank">VisualWebArena</a></td></tr>
+      </tbody></table>`,
+      projects: '',
+      output: '一个只操作公开网页的 browser agent，例如打开网页、提取信息、生成摘要。'
+    },
+    {
+      id:'stage7', title:'Stage 7: 评测、可观测性与安全',
+      items:[
+        '为 agent 准备固定测试集，而不是只看 demo。',
+        '记录成功率、失败原因、工具调用次数、成本、延迟。',
+        '会看 trace，知道失败发生在 prompt、工具、检索、模型还是状态管理。',
+        '给危险工具加人工确认，例如发邮件、删文件、付款、发布内容。',
+        '了解 prompt injection、data exfiltration、tool abuse 等风险。',
+        '会用回归测试防止 prompt 或工具改动后能力退化。'
+      ],
+      reading: `<table><thead><tr><th>Resource</th></tr></thead><tbody>
+        <tr><td><a href="https://platform.openai.com/docs/guides/evals" target="_blank">OpenAI Evals</a></td></tr>
+        <tr><td><a href="https://openai.com/agent-platform/" target="_blank">OpenAI Agent platform</a></td></tr>
+        <tr><td><a href="https://docs.smith.langchain.com/" target="_blank">LangSmith</a></td></tr>
+        <tr><td><a href="https://arxiv.org/abs/2308.03688" target="_blank">AgentBench</a></td></tr>
+        <tr><td><a href="https://arxiv.org/abs/2310.06770" target="_blank">SWE-bench</a></td></tr>
+      </tbody></table>`,
+      projects: '',
+      output: '一个 agent eval 表格，至少包含 20 个任务、期望结果、实际结果、失败分类。'
+    },
+    {
+      id:'stage8', title:'Stage 8: 交付一个真正的 Agent',
+      items:[
+        '有明确用户、明确任务、明确成功标准。',
+        '有日志、trace、错误重试、超时、成本上限。',
+        '有权限边界和人工确认机制。',
+        '有部署方式：CLI、Web app、Slack bot、GitHub Action 或后台任务。',
+        '有 README：怎么运行、怎么配置 key、怎么扩展工具、有哪些限制。'
+      ],
+      reading: '',
+      projects: '',
+      output: '一个别人能 clone 下来跑的 agent 项目。'
+    }
+  ]
+};
+
+const ladderData = [
+  { level:1, project:'Calculator Agent', desc:'最小 tool call loop' },
+  { level:2, project:'Web Research Agent', desc:'搜索、筛选、引用、总结' },
+  { level:3, project:'PDF QA Agent', desc:'RAG、chunk、retrieval、citation' },
+  { level:4, project:'Coding Review Agent', desc:'读取 diff、风险排序、测试建议' },
+  { level:5, project:'Browser Agent', desc:'页面观察、点击、提取、失败恢复' },
+  { level:6, project:'Claude Code-like Nano Agent', desc:'shell、文件编辑、权限、session、compact' },
+  { level:7, project:'OpenClaw-like Gateway', desc:'channel、routing、session、memory、heartbeat、delivery' },
+  { level:8, project:'Reusable Skill Pack', desc:'SKILL.md、脚本、模板、触发条件、smoke test' },
+  { level:9, project:'Multi-Agent Writer', desc:'planner、writer、reviewer 协作' },
+  { level:10, project:'Personal Agent', desc:'OpenClaw/Hermes-style 记忆、skills、消息入口' },
+  { level:11, project:'Production Harness', desc:'evals、trace、权限、CI、runner、回放' }
+];
+
+const resourcesData = {
+  officialGuides: {
+    title:'官方指南与博客',
+    rows:[
+      ['<a href="https://www.anthropic.com/engineering/building-effective-agents" target="_blank">Anthropic: Building effective agents</a>','Agent 设计入门必读，讲清 workflow 和 agent 的边界。'],
+      ['<a href="https://code.claude.com/docs/en/overview" target="_blank">Claude Code Overview</a>','当前最值得研究的 coding agent 产品文档入口。'],
+      ['<a href="https://code.claude.com/docs/en/sub-agents" target="_blank">Claude Code Subagents</a>','学任务拆分、上下文隔离、专用子代理。'],
+      ['<a href="https://code.claude.com/docs/en/hooks" target="_blank">Claude Code Hooks</a>','学如何拦截、校验和扩展 agent 行为。'],
+      ['<a href="https://docs.claude.com/en/docs/claude-code/github-actions" target="_blank">Claude Code GitHub Actions</a>','学 coding agent 如何进入 PR / issue 工作流。'],
+      ['<a href="https://resources.anthropic.com/hubfs/Claude%20Code%20Advanced%20Patterns_%20Subagents%2C%20MCP%2C%20and%20Scaling%20to%20Real%20Codebases.pdf" target="_blank">Claude Code Advanced Patterns</a>','Anthropic 官方材料，覆盖 subagents、MCP 和真实代码库扩展。'],
+      ['<a href="https://openai.com/business/guides-and-resources/a-practical-guide-to-building-ai-agents/" target="_blank">OpenAI: A practical guide to building agents</a>','面向产品和工程团队的 agent 落地指南。'],
+      ['<a href="https://openai.com/index/new-tools-for-building-agents/" target="_blank">OpenAI: New tools for building agents</a>','Responses API、Agents SDK、工具和 tracing 的官方介绍。'],
+      ['<a href="https://platform.openai.com/docs/guides/agents-sdk/" target="_blank">OpenAI Agents SDK</a>','OpenAI 原生 agent 开发入口。'],
+      ['<a href="https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/overview" target="_blank">Claude Tool Use</a>','Claude 工具调用机制。'],
+      ['<a href="https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/computer-use-tool" target="_blank">Claude Computer Use</a>','电脑操作类 agent 的官方参考。'],
+      ['<a href="https://ai.google.dev/gemini-api/docs/function-calling" target="_blank">Gemini Function Calling</a>','Gemini 工具调用官方文档。'],
+      ['<a href="https://ai.google.dev/gemini-api/docs/code-execution" target="_blank">Gemini Code Execution</a>','Gemini 代码执行工具。'],
+      ['<a href="https://google.github.io/adk-docs/" target="_blank">Google Agent Development Kit</a>','Google 的 agent 开发框架。'],
+      ['<a href="https://modelcontextprotocol.io/" target="_blank">Model Context Protocol</a>','Agent 连接工具和数据源的重要协议。']
+    ]
+  },
+  projectMap: {
+    title:'项目地图',
+    rows:[
+      ['Build From Scratch','<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">learn-claude-code</a>, <a href="https://github.com/shareAI-lab/claw0" target="_blank">claw0</a>, <a href="https://github.com/datawhalechina/hello-agents" target="_blank">hello-agents</a>','agent loop、tool registry、session、context compaction、gateway、trace、subagents。'],
+      ['Personal / Always-On Agents','<a href="https://github.com/openclaw/openclaw" target="_blank">OpenClaw</a>, <a href="https://github.com/NousResearch/hermes-agent" target="_blank">Hermes Agent</a>, <a href="https://github.com/ttguy0707/CyberClaw" target="_blank">CyberClaw</a>','长运行、skills、记忆、消息入口、权限、安全审计。'],
+      ['Coding Agents','<a href="https://code.claude.com/docs/en/overview" target="_blank">Claude Code</a>, <a href="https://github.com/openai/codex" target="_blank">OpenAI Codex</a>, <a href="https://github.com/opencode-ai/opencode" target="_blank">OpenCode</a>, <a href="https://github.com/All-Hands-AI/OpenHands" target="_blank">OpenHands</a>, <a href="https://github.com/SWE-agent/SWE-agent" target="_blank">SWE-agent</a>','真实代码库编辑、shell、测试、sandbox、PR 工作流。'],
+      ['Deep Research / RAG Agents','<a href="https://github.com/bytedance/deer-flow" target="_blank">DeerFlow</a>, <a href="https://docs.llamaindex.ai/" target="_blank">LlamaIndex</a>','搜索、抓取、检索、rerank、引用、报告生成。'],
+      ['Tutorial Encyclopedias','<a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank">GenAI_Agents</a>, <a href="https://github.com/datawhalechina/hello-agents" target="_blank">hello-agents</a>, <a href="https://github.com/huggingface/smolagents" target="_blank">smolagents</a>, <a href="https://github.com/NirDiamant/agents-towards-production" target="_blank">agents-towards-production</a>','横向看 ReAct、Plan-and-Execute、Multi-Agent、production patterns。'],
+      ['Browser / Multimodal Agents','<a href="https://github.com/browser-use/browser-use" target="_blank">browser-use</a>, <a href="https://github.com/bytedance/UI-TARS-desktop" target="_blank">UI-TARS-desktop</a>','浏览器/桌面操作、视觉理解、动作空间、失败恢复。']
+    ]
+  },
+  skillsProtocols: {
+    title:'Skills、协议与工具',
+    rows:[
+      ['Skills','<a href="https://code.claude.com/docs/en/skills" target="_blank">Claude Code Skills</a>, <a href="https://github.com/openclaw/openclaw/blob/main/docs/tools/skills.md" target="_blank">OpenClaw Skills</a>','把一类任务的流程知识、脚本、模板和验收标准打包成可复用能力。'],
+      ['MCP','<a href="https://modelcontextprotocol.io/" target="_blank">Model Context Protocol</a>','让 agent 标准化连接外部工具、数据源和服务。'],
+      ['A2A','<a href="https://google-a2a.github.io/A2A/specification/" target="_blank">Agent2Agent Protocol</a>','让不同 agent 之间发现、通信和协作。'],
+      ['ACP','<a href="https://agentclientprotocol.com/" target="_blank">Agent Client Protocol</a>','让编辑器、终端、IDE、宿主应用和 agent 之间形成统一接口。'],
+      ['Skill Quality','<a href="https://arxiv.org/abs/2603.15401" target="_blank">SWE-Skills-Bench</a>, <a href="https://arxiv.org/abs/2602.08004" target="_blank">Agent Skills analysis</a>','评估 skills 是否真的提升成功率，而不是制造新的 prompt 噪声。']
+    ]
+  },
+  modernSystems: {
+    title:'现代 Agent 系统',
+    rows:[
+      ['<a href="https://code.claude.com/docs/en/overview" target="_blank">Claude Code</a>','学 coding agent 的产品化形态：shell、文件、权限、hooks、subagents、MCP。'],
+      ['<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">learn-claude-code</a>','从零构建 Claude Code-like nano agent，适合理解 harness engineering。'],
+      ['<a href="https://github.com/shareAI-lab/claw0" target="_blank">claw0</a>','从零构建 OpenClaw-like agent gateway，覆盖 channel、routing、session、memory、delivery、concurrency。'],
+      ['<a href="https://github.com/datawhalechina/hello-agents" target="_blank">hello-agents</a>','中文智能体系统教程，适合从零开始补齐 Agent 原理与实践。'],
+      ['<a href="https://github.com/openclaw/openclaw" target="_blank">OpenClaw</a>','本地优先的个人 agent，适合研究长运行 agent 和系统级工具调用。'],
+      ['<a href="https://github.com/NousResearch/hermes-agent" target="_blank">Hermes Agent</a>','自托管、长期记忆、skills、消息网关和 toolsets。'],
+      ['<a href="https://github.com/ttguy0707/CyberClaw" target="_blank">CyberClaw</a>','透明可控 agent 架构，适合研究审计、两段式执行和安全边界。'],
+      ['<a href="https://github.com/bytedance/deer-flow" target="_blank">DeerFlow</a>','字节开源 long-horizon SuperAgent harness，适合研究 Deep Research、报告、slides、网页、图像和视频生成。'],
+      ['<a href="https://github.com/huggingface/smolagents" target="_blank">smolagents</a>','Hugging Face 轻量 agent 框架，CodeAgent 思路值得研究。'],
+      ['<a href="https://langchain-ai.github.io/langgraph/" target="_blank">LangGraph</a>','状态图和可控 agent 编排，仍然值得作为工程基础学习。'],
+      ['<a href="https://github.com/QwenLM/Qwen-Agent" target="_blank">Qwen-Agent</a>','国产模型生态里的工具调用、RAG、MCP agent 框架。'],
+      ['<a href="https://pydantic.dev/docs/ai/core-concepts/agent/" target="_blank">Pydantic AI</a>','类型安全和结构化输出，适合生产 Python agent。']
+    ]
+  },
+  legacy: {
+    title:'遗留或可选框架',
+    rows:[
+      ['<a href="https://docs.crewai.com/" target="_blank">CrewAI</a>','可了解 role/task/crew 抽象，但很多场景已经被更强的 coding agent / harness 形态覆盖。'],
+      ['<a href="https://microsoft.github.io/autogen/" target="_blank">AutoGen</a>','多 agent 对话框架经典项目，适合了解历史和论文，不必重押。'],
+      ['<a href="https://docs.langchain.com/" target="_blank">LangChain Agents</a>','生态仍重要，但建议重点转向 LangGraph 和具体工程模式。']
+    ]
+  },
+  papers: {
+    title:'论文',
+    rows:[
+      ['<a href="https://arxiv.org/abs/2210.03629" target="_blank">ReAct</a>','Reasoning + acting 的基础范式。'],
+      ['<a href="https://arxiv.org/abs/2302.04761" target="_blank">Toolformer</a>','模型学习何时调用工具。'],
+      ['<a href="https://arxiv.org/abs/2303.11366" target="_blank">Reflexion</a>','语言反馈和自我改进。'],
+      ['<a href="https://arxiv.org/abs/2304.03442" target="_blank">Generative Agents</a>','记忆、反思、规划驱动的模拟 agent。'],
+      ['<a href="https://arxiv.org/abs/2305.16291" target="_blank">Voyager</a>','开放世界中的长期学习 agent。'],
+      ['<a href="https://arxiv.org/abs/2308.08155" target="_blank">AutoGen</a>','多 agent 对话框架。'],
+      ['<a href="https://arxiv.org/abs/2308.03688" target="_blank">AgentBench</a>','Agent 能力评测。'],
+      ['<a href="https://arxiv.org/abs/2307.13854" target="_blank">WebArena</a>','真实网页环境下的 agent benchmark。'],
+      ['<a href="https://arxiv.org/abs/2310.06770" target="_blank">SWE-bench</a>','真实 GitHub issue 修复评测。'],
+      ['<a href="https://arxiv.org/abs/2405.15793" target="_blank">SWE-agent</a>','软件工程 agent 的 agent-computer interface。'],
+      ['<a href="https://arxiv.org/abs/2604.14228" target="_blank">Dive into Claude Code</a>','从系统设计角度分析 Claude Code 这类 coding agent 的 harness、权限、压缩和扩展机制。'],
+      ['<a href="https://arxiv.org/abs/2605.13357" target="_blank">AI Harness Engineering</a>','把 harness 作为 agent 能力来源来研究。'],
+      ['<a href="https://arxiv.org/abs/2602.14690" target="_blank">Configuring Agentic AI Coding Tools</a>','对 Claude Code、Codex、Gemini、Cursor 等 coding tools 的配置机制分析。'],
+      ['<a href="https://arxiv.org/abs/2604.04759" target="_blank">Your Agent, Their Asset</a>','OpenClaw 等本地 agent 的真实安全风险分析。']
+    ]
+  },
+  githubRepos: {
+    title:'GitHub 仓库',
+    rows:[
+      ['<a href="https://github.com/datawhalechina/hello-agents" target="_blank">datawhalechina/hello-agents</a>','中文智能体系统教程，从零开始构建智能体。'],
+      ['<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">shareAI-lab/learn-claude-code</a>','Bash is all you need，从 0 到 1 学 Claude Code-like agent harness。'],
+      ['<a href="https://github.com/shareAI-lab/claw0" target="_blank">shareAI-lab/claw0</a>','从 0 到 1 学 OpenClaw-like gateway，10 个渐进章节覆盖 agent loop 到 concurrency。'],
+      ['<a href="https://github.com/openclaw/openclaw" target="_blank">openclaw/openclaw</a>','研究本地个人 agent、skills、长运行任务、系统工具和权限边界。'],
+      ['<a href="https://github.com/NousResearch/hermes-agent" target="_blank">NousResearch/hermes-agent</a>','研究自托管 agent、长期记忆、skills、toolsets、多平台消息网关。'],
+      ['<a href="https://github.com/ttguy0707/CyberClaw" target="_blank">ttguy0707/CyberClaw</a>','研究透明 agent、安全审计、两段式执行、双水位记忆和心跳任务。'],
+      ['<a href="https://github.com/bytedance/deer-flow" target="_blank">bytedance/deer-flow</a>','Deep Research / long-horizon agent，适合学习搜索、报告生成、沙箱、memory、skills、subagents、message gateway。'],
+      ['<a href="https://github.com/NirDiamant/GenAI_Agents" target="_blank">NirDiamant/GenAI_Agents</a>','综合教程库，适合横向比较 ReAct、Plan-and-Execute、Multi-Agent 等实现方式。'],
+      ['<a href="https://github.com/NirDiamant/agents-towards-production" target="_blank">NirDiamant/agents-towards-production</a>','production-grade agent 教程库，适合补工程化组件。'],
+      ['<a href="https://github.com/huggingface/smolagents" target="_blank">huggingface/smolagents</a>','轻量 CodeAgent 风格框架，适合研究"让模型写代码执行动作"的范式。'],
+      ['<a href="https://github.com/openai/codex" target="_blank">openai/codex</a>','OpenAI 开源 coding agent CLI，适合研究 sandbox、approval、CLI 产品形态。'],
+      ['<a href="https://github.com/opencode-ai/opencode" target="_blank">opencode-ai/opencode</a>','终端优先的开源 coding agent，适合对照 Claude Code / Codex。'],
+      ['<a href="https://github.com/langchain-ai/langgraph" target="_blank">langchain-ai/langgraph</a>','状态图和可控 agent 编排。'],
+      ['<a href="https://github.com/openai/openai-agents-python" target="_blank">openai/openai-agents-python</a>','OpenAI Agents SDK Python。'],
+      ['<a href="https://github.com/QwenLM/Qwen-Agent" target="_blank">QwenLM/Qwen-Agent</a>','Qwen 生态 agent 框架。'],
+      ['<a href="https://github.com/browser-use/browser-use" target="_blank">browser-use/browser-use</a>','浏览器 agent 实战。'],
+      ['<a href="https://github.com/bytedance/UI-TARS-desktop" target="_blank">bytedance/UI-TARS-desktop</a>','多模态桌面 agent stack，适合研究视觉 UI 操作。'],
+      ['<a href="https://github.com/SWE-agent/SWE-agent" target="_blank">SWE-agent/SWE-agent</a>','软件工程 agent。'],
+      ['<a href="https://github.com/All-Hands-AI/OpenHands" target="_blank">All-Hands-AI/OpenHands</a>','开源 coding agent。'],
+      ['<a href="https://github.com/microsoft/ai-agents-for-beginners" target="_blank">microsoft/ai-agents-for-beginners</a>','系统化入门课程。'],
+      ['<a href="https://github.com/jjyaoao/HelloAgents" target="_blank">jjyaoao/HelloAgents</a>','基于 OpenAI 原生 API 的生产级多智能体框架。']
+    ]
+  },
+  blogs: {
+    title:'深度博客',
+    rows:[
+      ['<a href="https://lilianweng.github.io/posts/2023-06-23-agent/" target="_blank">Lilian Weng: LLM Powered Autonomous Agents</a>','经典长文，系统整理 agent 架构、记忆、规划和工具使用。'],
+      ['<a href="https://simonwillison.net/tags/llms/" target="_blank">Simon Willison: AI/LLM writing</a>','非常务实的 LLM 工程观察，适合补工程直觉。'],
+      ['<a href="https://blog.langchain.com/" target="_blank">LangChain Blog</a>','LangGraph、LangSmith、agent 工程实践。'],
+      ['<a href="https://developers.googleblog.com/agent-development-kit-easy-to-build-multi-agent-applications/" target="_blank">Google Developers Blog: ADK</a>','Google ADK 官方发布文章。']
+    ]
+  },
+  claudeCodeStudy: {
+    title:'Claude Code 学习路径',
+    rows:[
+      ['<a href="https://code.claude.com/docs/en/tutorials" target="_blank">Claude Code Common Workflows</a>','官方工作流教程，适合学日常使用和项目协作。'],
+      ['<a href="https://code.claude.com/docs/en/overview" target="_blank">Claude Code Overview</a>','官方入口，理解产品能力和命令行工作方式。'],
+      ['<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">learn-claude-code</a>','从零复刻 Claude Code-like agent，适合学 harness 最小实现。'],
+      ['<a href="https://claudecoding.dev/" target="_blank">Claude Code 源码解析</a>','中文架构解读，适合按模块理解实现思路。'],
+      ['<a href="https://code.claudecn.com/" target="_blank">Claude Code 源码分析地图</a>','用地图方式拆解 agent loop、工具、命令和多代理协作。'],
+      ['<a href="https://arxiv.org/abs/2604.14228" target="_blank">Dive into Claude Code</a>','从研究视角总结 Claude Code 的设计空间和 agent harness 模式。'],
+      ['<a href="https://arxiv.org/abs/2604.17460" target="_blank">Agentic Education</a>','用 Claude Code 学 Claude Code 的交互式课程思路。']
+    ]
+  }
+};
+
+// ===== State =====
+let currentTab = 'learn';
+let currentSidebarId = 'stage0';
+
+// ===== Storage =====
+const STORAGE_KEY = 'agent-learning-hub-state';
+function loadState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch(e) { return {}; }
+}
+function saveState(state) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+function isChecked(key) {
+  return !!loadState()[key];
+}
+function toggleCheck(key) {
+  const state = loadState();
+  state[key] = !state[key];
+  saveState(state);
+  renderAll();
+}
+
+// ===== Notes =====
+function getNoteKey(stageId) { return `note-${stageId}`; }
+function getNote(stageId) { return localStorage.getItem(getNoteKey(stageId)) || ''; }
+function saveNote(stageId, text) {
+  localStorage.setItem(getNoteKey(stageId), text);
+}
+function renderNoteEditor(stageId) {
+  const note = getNote(stageId);
+  const hasNote = note.trim().length > 0;
+  const editorId = `note-editor-${stageId}`;
+  const isEditing = window._editingNote === stageId;
+  const isPreviewing = window._previewNote === stageId;
+
+  let html = `<div class="note-editor" id="${editorId}">`;
+
+  if (isEditing) {
+    // Editing mode
+    html += `<div class="note-editor-area">`;
+    if (isPreviewing) {
+      let previewHtml = '<p style="color:var(--text-tertiary);font-style:italic">开始输入即可预览</p>';
+      try {
+        if (typeof marked !== 'undefined' && note.trim()) {
+          previewHtml = marked.parse(note);
+        }
+      } catch(e) {}
+      html += `<div class="note-preview-pane open" id="note-preview-pane-${stageId}">${previewHtml}</div>`;
+    }
+    html += `<textarea class="note-textarea" id="note-textarea-${stageId}" oninput="debouncedPreview('${stageId}')" placeholder="用 Markdown 记录你的理解...&#10;&#10;支持标题、列表、代码块、引用等格式">${escapeHtml(note)}</textarea>`;
+    html += `<div class="note-toolbar">`;
+    if (isPreviewing) {
+      html += `<span class="markdown-preview-toggle" onclick="saveNote('${stageId}',document.getElementById('note-textarea-${stageId}').value);renderAll()">🔄 刷新</span>`;
+      html += `<span class="markdown-preview-toggle" onclick="window._previewNote=null;renderAll()" style="color:var(--text-tertiary)">✕ 关闭</span>`;
+    } else {
+      html += `<span class="markdown-preview-toggle" onclick="window._previewNote='${stageId}';saveNote('${stageId}',document.getElementById('note-textarea-${stageId}').value);renderAll()">👁 预览</span>`;
+    }
+    html += `<span class="note-hint">Markdown 语法支持</span>`;
+    html += `<button class="note-btn" onclick="saveNote('${stageId}',document.getElementById('note-textarea-${stageId}').value);renderAll()">保存</button>`;
+    html += `<button class="note-btn primary" onclick="window._editingNote=null;window._previewNote=null;saveNote('${stageId}',document.getElementById('note-textarea-${stageId}').value);renderAll()">完成</button>`;
+    html += `</div></div>`;
+  } else {
+    // Preview mode
+    if (hasNote) {
+      let rendered = note;
+      try {
+        if (typeof marked !== 'undefined') {
+          rendered = marked.parse(note);
+        }
+      } catch(e) {}
+      html += `<div class="note-preview has-content" onclick="window._editingNote='${stageId}';window._previewNote='${stageId}';renderAll()">`;
+      html += `<div class="note-body"><div class="note-title">📝 你的笔记</div>${rendered}</div>`;
+      html += `<button class="note-btn" onclick="event.stopPropagation();window._editingNote='${stageId}';window._previewNote='${stageId}';renderAll()">编辑</button>`;
+      html += `</div>`;
+    } else {
+      html += `<div class="note-preview" onclick="window._editingNote='${stageId}';window._previewNote='${stageId}';renderAll()">`;
+      html += `<span class="note-empty">📝 点击这里记录你的理解...</span>`;
+      html += `</div>`;
+    }
+  }
+
+  html += `</div>`;
+  return html;
+}
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+// ===== Debounced live preview =====
+const _debounceTimers = {};
+function debouncedPreview(stageId) {
+  clearTimeout(_debounceTimers[stageId]);
+  _debounceTimers[stageId] = setTimeout(() => {
+    const previewPane = document.getElementById(`note-preview-pane-${stageId}`);
+    if (!previewPane || !previewPane.classList.contains('open')) return;
+    const ta = document.getElementById(`note-textarea-${stageId}`);
+    if (!ta) return;
+    const text = ta.value;
+    if (typeof marked !== 'undefined') {
+      previewPane.innerHTML = text.trim()
+        ? marked.parse(text)
+        : '<p style="color:var(--text-tertiary);font-style:italic">开始输入即可预览</p>';
+    }
+  }, 300);
+}
+
+// ===== Theme =====
+function initTheme() {
+  const saved = localStorage.getItem('agent-learning-theme');
+  if (saved === 'dark' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    document.documentElement.setAttribute('data-theme','dark');
+    document.getElementById('themeBtn').textContent = '☀️';
+  }
+}
+function toggleTheme() {
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  document.documentElement.setAttribute('data-theme', isDark ? '' : 'dark');
+  localStorage.setItem('agent-learning-theme', isDark ? 'light' : 'dark');
+  document.getElementById('themeBtn').textContent = isDark ? '🌙' : '☀️';
+}
+
+// ===== Mobile Sidebar =====
+function toggleSidebar() {
+  document.getElementById('sidebar').classList.toggle('open');
+  document.getElementById('sidebarOverlay').classList.toggle('open');
+}
+function closeSidebar() {
+  document.getElementById('sidebar').classList.remove('open');
+  document.getElementById('sidebarOverlay').classList.remove('open');
+}
+
+// ===== Tabs =====
+function switchTab(tab) {
+  currentTab = tab;
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
+  if (tab === 'learn') currentSidebarId = 'stage0';
+  else if (tab === 'ladder') currentSidebarId = 'ladder';
+  else currentSidebarId = 'officialGuides';
+  renderAll();
+  document.getElementById('mainContent').scrollTop = 0;
+}
+
+// ===== Sidebar Navigation =====
+let ignoreScrollSpy = false;
+function switchSidebar(id) {
+  currentSidebarId = id;
+  ignoreScrollSpy = true;
+  renderAll();
+  const el = document.getElementById(id);
+  if (el) el.scrollIntoView({ behavior:'smooth', block:'start' });
+  closeSidebar();
+  setTimeout(() => { ignoreScrollSpy = false; }, 600);
+}
+
+// ===== Search =====
+function doSearch() {
+  const q = document.getElementById('searchInput').value.toLowerCase().trim();
+  renderAll(q);
+}
+
+// ===== Progress Calculation =====
+function calcStageProgress(stageId) {
+  const stage = learningData.stages.find(s=>s.id===stageId);
+  if (!stage) return {done:0,total:0};
+  const total = stage.items.length;
+  let done = 0;
+  stage.items.forEach((_,i)=>{ if(isChecked(`${stageId}-${i}`)) done++; });
+  return {done,total};
+}
+function calcTotalProgress() {
+  let total=0,done=0;
+  learningData.stages.forEach(s=>{
+    s.items.forEach((_,i)=>{ total++; if(isChecked(`${s.id}-${i}`)) done++; });
+  });
+  ladderData.forEach(l=>{ total++; if(isChecked(`ladder-${l.level}`)) done++; });
+  return {done,total};
+}
+
+// ===== Render =====
+function renderAll(searchQuery) {
+  // Save any in-progress note before re-rendering
+  if (window._editingNote) {
+    const ta = document.getElementById(`note-textarea-${window._editingNote}`);
+    if (ta) saveNote(window._editingNote, ta.value);
+  }
+  renderSidebar();
+  renderMain(searchQuery);
+  updateProgressBar();
+}
+
+function renderSidebar() {
+  const container = document.getElementById('sidebarContent');
+  let html = '';
+  if (currentTab === 'learn') {
+    html += '<div class="sidebar-label">学习路线</div>';
+    learningData.stages.forEach(s => {
+      const p = calcStageProgress(s.id);
+      const badge = p.total > 0 ? `${p.done}/${p.total}` : '';
+      html += `<button class="sidebar-link${currentSidebarId===s.id?' active':''}" onclick="switchSidebar('${s.id}')">${s.title}<span class="sidebar-badge">${badge}</span></button>`;
+    });
+  } else if (currentTab === 'ladder') {
+    html += '<div class="sidebar-label">项目阶梯</div>';
+    html += `<button class="sidebar-link${currentSidebarId==='ladder'?' active':''}" onclick="switchSidebar('ladder')">全部项目</button>`;
+  } else if (currentTab === 'resources') {
+    html += '<div class="sidebar-label">精选资源</div>';
+    const sections = [
+      {id:'officialGuides',label:'官方指南与博客'},
+      {id:'projectMap',label:'项目地图'},
+      {id:'skillsProtocols',label:'Skills、协议与工具'},
+      {id:'modernSystems',label:'现代 Agent 系统'},
+      {id:'legacy',label:'遗留/可选框架'},
+      {id:'papers',label:'论文'},
+      {id:'githubRepos',label:'GitHub 仓库'},
+      {id:'blogs',label:'深度博客'},
+      {id:'claudeCodeStudy',label:'Claude Code 学习路径'}
+    ];
+    sections.forEach(sec => {
+      html += `<button class="sidebar-link${currentSidebarId===sec.id?' active':''}" onclick="switchSidebar('${sec.id}')">${sec.label}</button>`;
+    });
+    // Learning Principles & Contributing
+    html += '<div class="sidebar-label" style="margin-top:8px">其他</div>';
+    html += `<button class="sidebar-link${currentSidebarId==='principles'?' active':''}" onclick="switchSidebar('principles')">学习原则</button>`;
+    html += `<button class="sidebar-link${currentSidebarId==='contributing'?' active':''}" onclick="switchSidebar('contributing')">贡献指南</button>`;
+  }
+  container.innerHTML = html;
+}
+
+function matchSearch(text, q) {
+  if (!q) return true;
+  return text.toLowerCase().includes(q);
+}
+
+function highlightText(text, q) {
+  if (!q) return text;
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>');
+}
+
+function renderMain(q) {
+  const main = document.getElementById('mainContent');
+  let html = '';
+  let visibleCount = 0;
+
+  if (currentTab === 'learn') {
+    // "What To Learn Now" section
+    if (!q || matchSearch('Claude Code Codex harness OpenClaw Hermes Skills MCP A2A ACP Evaluation safety 当前更值得投入', q)) {
+      html += '<div class="section-desc">Agent 领域变化很快。当前更值得投入的不是老式"角色扮演多 agent 框架"，而是这些更贴近真实生产力的方向：</div>';
+      html += '<div class="priority-grid">';
+      learningData.priorityTable.forEach(p => {
+        if (q && !matchSearch(`${p.learn} ${p.why}`, q)) return;
+        visibleCount++;
+        html += `<div class="pg-row"><div class="pg-priority">${p.priority}</div><div><span class="pg-title">${highlightText(p.learn,q)}</span></div><div>${highlightText(p.why,q)}</div></div>`;
+      });
+      html += '</div>';
+    }
+
+    // Global progress
+    const tp = calcTotalProgress();
+    html += `<div id="globalProgress">${tp.done === tp.total && tp.total > 0 ? '<div style="text-align:center;padding:8px 0 16px;font-weight:700;color:var(--success);font-size:1.05em">🎉 全部完成！你已经完整走完了 Agent 学习路线。</div>' : ''}</div>`;
+
+    // Stages
+    learningData.stages.forEach(stage => {
+      // Check if stage matches search
+      let stageMatch = !q || matchSearch(stage.title, q);
+      let matchingItems = stage.items.filter((item,i) => !q || matchSearch(item, q));
+      let outputMatch = !q || matchSearch(stage.output, q);
+      let readingMatch = !q || matchSearch(stage.reading, q);
+      let projectsMatch = !q || matchSearch(stage.projects, q);
+
+      if (!stageMatch && matchingItems.length === 0 && !outputMatch && !readingMatch && !projectsMatch) return;
+      visibleCount++;
+
+      const p = calcStageProgress(stage.id);
+      const doneClass = p.done === p.total && p.total > 0 ? 'green' : (p.done > 0 ? 'yellow' : 'neutral');
+      const badgeText = p.done === p.total && p.total > 0 ? '✓ 完成' : `${p.done}/${p.total}`;
+
+      html += `<div class="stage-card" id="${stage.id}">`;
+      html += `<div class="stage-card-header">`;
+      html += `<span class="stage-card-title">${highlightText(stage.title, q)}</span>`;
+      html += `<span class="stage-card-badge ${doneClass}">${badgeText}</span>`;
+      html += `</div>`;
+      html += `<div class="stage-progress"><div class="stage-progress-fill" style="width:${p.total>0?(p.done/p.total*100):0}%"></div></div>`;
+
+      // Items
+      stage.items.forEach((item, i) => {
+        const key = `${stage.id}-${i}`;
+        const done = isChecked(key);
+        const showItem = !q || matchSearch(item, q) || (stageMatch && !q);
+        if (!showItem) return;
+        html += `<div class="check-item${done?' done':''}" onclick="toggleCheck('${key}')">`;
+        html += `<div class="check-box"></div>`;
+        html += `<span class="check-label">${highlightText(item, q)}</span>`;
+        html += `</div>`;
+      });
+
+      // Output
+      if (stage.output && (!q || matchSearch(stage.output, q))) {
+        html += `<div class="sub-content"><strong>🎯 产出：</strong>${highlightText(stage.output, q)}</div>`;
+        html += renderNoteEditor(stage.id);
+      }
+
+      // Reading
+      if (stage.reading && (!q || matchSearch(stage.reading, q))) {
+        html += `<div class="sub-content"><strong>📖 推荐阅读：</strong></div>`;
+        html += `<div class="sub-content">${stage.reading}</div>`;
+      }
+
+      // Projects
+      if (stage.projects && (!q || matchSearch(stage.projects, q))) {
+        html += `<div class="sub-content"><strong>🔗 开源项目参考：</strong></div>`;
+        html += `<div class="sub-content">${stage.projects}</div>`;
+      }
+
+      html += `</div>`;
+    });
+  } else if (currentTab === 'ladder') {
+    html += '<div class="section-desc">以下项目不按知识分类，按"如果你本周要做个东西"来排。每一档做一个可运行作品，从 Calculator Agent 一路做到 Production Harness。</div>';
+    html += `<div id="ladderSection">`;
+    ladderData.forEach(l => {
+      if (q && !matchSearch(`${l.project} ${l.desc}`, q)) return;
+      visibleCount++;
+      const key = `ladder-${l.level}`;
+      const done = isChecked(key);
+      html += `<div class="ladder-card${done?' done':''}" onclick="toggleCheck('${key}')" id="ladder">`;
+      html += `<div class="ladder-num">${l.level}</div>`;
+      html += `<div class="ladder-info"><div class="ladder-title">${highlightText(l.project,q)}</div><div class="ladder-desc">${highlightText(l.desc,q)}</div></div>`;
+      html += `<div class="ladder-check"><div class="check-box" style="${done?'background:var(--success);border-color:var(--success)':''}">${done?'<span style=color:#fff;font-size:0.7em;font-weight:700>✓</span>':''}</div></div>`;
+      html += `</div>`;
+    });
+    html += `</div>`;
+  } else if (currentTab === 'resources') {
+    const sections = [
+      resourcesData.officialGuides,
+      resourcesData.projectMap,
+      resourcesData.skillsProtocols,
+      resourcesData.modernSystems,
+      resourcesData.legacy,
+      resourcesData.papers,
+      resourcesData.githubRepos,
+      resourcesData.blogs,
+      resourcesData.claudeCodeStudy
+    ];
+    sections.forEach(sec => {
+      const secId = Object.keys(resourcesData).find(k=>resourcesData[k]===sec);
+      let secMatch = !q;
+      let filtered = sec.rows;
+      if (q) {
+        filtered = sec.rows.filter(r => matchSearch(r.join(' '), q));
+        secMatch = filtered.length > 0;
+      }
+      if (!secMatch) return;
+      visibleCount++;
+      const headers = sec.rows[0] && sec.rows[0].length === 3 ? ['名称','来源','解决的问题'] : ['名称','说明'];
+      html += `<div class="resource-section-title" id="${secId}">${highlightText(sec.title, q)}</div>`;
+      html += '<div class="resource-table-wrap"><table><thead><tr>';
+      headers.forEach(h => html += `<th>${h}</th>`);
+      html += '</tr></thead><tbody>';
+      filtered.forEach(r => {
+        html += '<tr>';
+        r.forEach(c => html += `<td>${highlightText(c, q)}</td>`);
+        html += '</tr>';
+      });
+      html += '</tbody></table></div>';
+    });
+
+    // Learning Principles
+    const principles = [
+      'Build first, then read deeper.',
+      'Prefer small reliable agents over impressive demos.',
+      'Use tools with strict schemas.',
+      'Add evals before you add more agents.',
+      'Trace every important run.',
+      'Treat multi-agent as a coordination problem.',
+      'Keep humans in the loop for risky actions.',
+      'Respect platform rules, copyrights, and data access boundaries.'
+    ];
+    let princMatch = !q || principles.some(p=>matchSearch(p,q)) || matchSearch('学习原则 Learning Principles', q);
+    if (princMatch) {
+      visibleCount++;
+      html += `<div class="resource-section-title" id="principles">学习原则 / Learning Principles</div>`;
+      html += '<div class="info-cards">';
+      principles.forEach(p => {
+        if (q && !matchSearch(p, q)) return;
+        html += `<div class="info-card"><div class="info-card-body">${highlightText(p, q)}</div></div>`;
+      });
+      html += '</div>';
+    }
+
+    // Contributing
+    let contrMatch = !q || matchSearch('贡献 Contributing 请优先 请避免 good contributions', q);
+    if (contrMatch) {
+      visibleCount++;
+      html += `<div class="resource-section-title" id="contributing">贡献指南 / Contributing</div>`;
+      html += '<div class="info-cards">';
+      html += `<div class="info-card"><div class="info-card-title">✅ 请优先提交</div><div class="info-card-body"><ul><li>官方文档和官方工程博客</li><li>高质量论文和 benchmark</li><li>有可运行代码的开源仓库</li><li>有原创见解的严肃技术博客</li><li>帮助学习者练习特定技能的小项目</li></ul></div></div>`;
+      html += `<div class="info-card"><div class="info-card-title">❌ 请避免</div><div class="info-card-body"><ul><li>搬运的平台帖子</li><li>没有实质内容的课程广告</li><li>私有或付费内容</li><li>绕过平台规则的爬取导向内容</li></ul></div></div>`;
+      html += '</div>';
+    }
+
+    // Maintainer
+    if (!q || matchSearch('陈思州 maintainer 维护者', q)) {
+      html += `<div style="text-align:center;margin-top:40px;padding:20px;color:var(--text-secondary);font-size:0.9em">Curated by <a href="https://github.com/jjyaoao" target="_blank">陈思州</a> (Datawhale 成员) <a href="https://www.xiaohongshu.com/user/profile/67b9cc34000000000e013517" target="_blank" style="color:#e93c49">小红书</a></div>`;
+    }
+  }
+
+  // No results
+  if (visibleCount === 0 && q) {
+    html = `<div class="no-results show"><div class="no-results-icon">🔍</div><div>没有找到匹配 "<strong>${q}</strong>" 的内容</div><div style="color:var(--text-tertiary);margin-top:8px;font-size:0.9em">试试其他关键词，比如 "tool call"、"MCP"、"eval"</div></div>`;
+  }
+
+  // How to use
+  if (!q && currentTab === 'learn') {
+    html = `<div class="info-cards" style="margin-bottom:20px">
+      <div class="info-card"><div class="info-card-title">🆕 新手</div><div class="info-card-body">按「Learning Todo List」从上到下做，每完成一项就打勾。</div></div>
+      <div class="info-card"><div class="info-card-title">💡 已会 LLM 应用</div><div class="info-card-body">从 Stage 2 或 Stage 3 开始，重点补 Agent loop、工具调用、评测和工程化。</div></div>
+      <div class="info-card"><div class="info-card-title">🔨 想做项目</div><div class="info-card-body">直接看「项目阶梯」，每一档做一个可运行作品。</div></div>
+      <div class="info-card"><div class="info-card-title">📚 只想找资料</div><div class="info-card-body">看「精选资源」，优先读官方文档和经典论文。</div></div>
+    </div>` + html;
+  }
+
+  main.innerHTML = `<div class="main-inner">${html}</div>`;
+  updateProgressBar();
+  updateSidebarFromScroll();
+}
+
+function updateProgressBar() {
+  const tp = calcTotalProgress();
+  const pct = tp.total > 0 ? Math.round(tp.done/tp.total*100) : 0;
+  const bar = document.getElementById('globalProgress');
+  if (bar) {
+    bar.innerHTML = `
+      <div class="progress-stats"><span>总进度</span><span><strong>${tp.done}</strong> / ${tp.total} <span style="font-size:0.85em;color:var(--text-tertiary)">(${pct}%)</span></span></div>
+      <div class="progress-bar-wrap"><div class="progress-bar-fill" style="width:${pct}%"></div></div>
+      ${tp.done === tp.total && tp.total > 0 ? '<div style="text-align:center;padding:8px 0 16px;font-weight:700;color:var(--success);font-size:1.05em">🎉 全部完成！你已经完整走完了 Agent 学习路线。</div>' : ''}
+    `;
+  }
+}
+
+function updateSidebarFromScroll() {
+  if (ignoreScrollSpy) return;
+  // Update active sidebar link based on visible content
+  if (currentTab === 'learn') {
+    const cards = document.querySelectorAll('.stage-card');
+    let closest = null;
+    let minDist = Infinity;
+    cards.forEach(card => {
+      const rect = card.getBoundingClientRect();
+      const dist = Math.abs(rect.top - 150);
+      if (dist < minDist) { minDist = dist; closest = card; }
+    });
+    if (closest) {
+      const id = closest.id;
+      if (id && id !== currentSidebarId) {
+        currentSidebarId = id;
+        renderSidebar();
+      }
+    }
+  }
+}
+
+// ===== Init =====
+function init() {
+  initTheme();
+  window._editingNote = null;
+  window._previewNote = null;
+  if (typeof marked !== 'undefined') {
+    marked.setOptions({ breaks: true, gfm: true });
+  }
+
+  // Tab clicks
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+  });
+
+  // Mobile menu button visibility
+  const mmb = document.querySelector('.mobile-menu-btn');
+  if (window.innerWidth <= 768) mmb.style.display = 'flex';
+
+  // Scroll spy
+  document.getElementById('mainContent').addEventListener('scroll', updateSidebarFromScroll, {passive:true});
+
+  // Keyboard shortcut: Ctrl+K for search
+  document.addEventListener('keydown', e => {
+    if ((e.ctrlKey||e.metaKey) && e.key === 'k') {
+      e.preventDefault();
+      document.getElementById('searchInput').focus();
+    }
+  });
+
+  // Initial render
+  renderAll();
+}
+
+window.addEventListener('DOMContentLoaded', init);
+window.addEventListener('resize', () => {
+  const mmb = document.querySelector('.mobile-menu-btn');
+  mmb.style.display = window.innerWidth <= 768 ? 'flex' : 'none';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 概述

将 README.md 转化为一个可交互的纯前端学习仪表盘，解决原 Markdown 中复选框无法可视化打勾、内容密度高难以导航的问题。

单 HTML 文件，零依赖（marked.js 通过 CDN 加载），双击即可使用。

## 核心功能

### 进度追踪

- Stage 0-8 全部 45 个学习任务 + Project Ladder 11 级项目均可勾选
- localStorage 持久化勾选状态，刷新/关闭浏览器不丢失
- 顶部总进度条 + 每个 Stage 独立进度条 + badge 完成计数

### 布局与导航

- 顶部 Tab：学习路线 / 项目阶梯 / 精选资源 三大板块切换
- 左侧子导航：按 Stage 或资源分类快速跳转，滚动时自动高亮当前位置
- 全局搜索：实时过滤（Ctrl+K 聚焦），关键词高亮
- 响应式：桌面端表格展示，移动端自动切换卡片布局 + 抽屉侧栏

### 暗色模式

- 默认跟随系统偏好，右上角手动切换按钮，偏好存入 localStorage

### Markdown 笔记编辑器

- 每个 Stage 产出区下方内嵌编辑器，用于记录学习心得
- 支持 GFM 语法实时预览（300ms 防抖），笔记内容 localStorage 持久化
- 局部更新预览 DOM，不重建 textarea，保留光标位置和撤销历史

## 使用方式

直接双击 HTML 文件在浏览器中打开即可，无需安装任何依赖。

## 文件

新增 `learning.html`（或其他命名），纯静态文件，CSS/JS 全内联。

## 预览

<img width="3839" height="2073" alt="示例1" src="https://github.com/user-attachments/assets/1ca2317b-e140-4e9e-804b-ae90e767a41a" />
<img width="3840" height="2072" alt="示例2" src="https://github.com/user-attachments/assets/c34e3a0f-e468-457b-aadf-b8396604e96e" />
<img width="3840" height="2066" alt="示例3" src="https://github.com/user-attachments/assets/53ee1d4b-6e22-4539-b14f-b1c151ec5262" />
<img width="3840" height="2070" alt="示例4" src="https://github.com/user-attachments/assets/57b6ce0e-1fd5-47ca-95bf-cd06152c41b0" />
<img width="3840" height="2073" alt="示例5" src="https://github.com/user-attachments/assets/9763d691-5f73-4cc6-8103-17e66fde6368" />
