### PR TITLE
Add Learn-OpenClaw to curated resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Agent 领域变化很快。当前更值得投入的不是老式“角色扮演�
 
 | Layer | Study These | Learn |
 | --- | --- | --- |
-| Build From Scratch | [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code), [claw0](https://github.com/shareAI-lab/claw0), [hello-agents](https://github.com/datawhalechina/hello-agents) | agent loop、tool registry、session、context compaction、gateway、trace、subagents。 |
+| Build From Scratch | [learn-claude-code](https://github.com/shareAI-lab/learn-claude-code), [claw0](https://github.com/shareAI-lab/claw0), [hello-agents](https://github.com/datawhalechina/hello-agents), [Learn-OpenClaw](https://github.com/lasywolf/Learn-OpenClaw) | agent loop、tool registry、session、context compaction、gateway、trace、subagents；Learn-OpenClaw 适合 9 小时速通五大模块。 |
 | Personal / Always-On Agents | [OpenClaw](https://github.com/openclaw/openclaw), [Hermes Agent](https://github.com/NousResearch/hermes-agent), [CyberClaw](https://github.com/ttguy0707/CyberClaw) | 长运行、skills、记忆、消息入口、权限、安全审计。 |
 | Coding Agents | [Claude Code](https://code.claude.com/docs/en/overview), [OpenAI Codex](https://github.com/openai/codex), [OpenCode](https://github.com/opencode-ai/opencode), [OpenHands](https://github.com/All-Hands-AI/OpenHands), [SWE-agent](https://github.com/SWE-agent/SWE-agent), [pi](https://github.com/earendil-works/pi) | 真实代码库编辑、shell、测试、sandbox、PR 工作流。 |
 | Agent Harness / SuperAgent Runtime | [DeerFlow](https://github.com/bytedance/deer-flow), [LangGraph](https://langchain-ai.github.io/langgraph/) | 长任务执行、sandbox、memory、skills、subagents、message gateway、trace。 |
@@ -315,6 +315,7 @@ Agent 领域变化很快。当前更值得投入的不是老式“角色扮演�
 | Repo | Why It Is Useful |
 | --- | --- |
 | [datawhalechina/hello-agents](https://github.com/datawhalechina/hello-agents) | 中文智能体系统教程，从零开始构建智能体。 |
+| [lasywolf/Learn-OpenClaw](https://github.com/lasywolf/Learn-OpenClaw) | 面向零基础/求职的 Agent 速通教程，9 小时覆盖 Node→RAG→Tool→Memory→Multi-Agent 五大模块。 |
 | [shareAI-lab/learn-claude-code](https://github.com/shareAI-lab/learn-claude-code) | Bash is all you need，从 0 到 1 学 Claude Code-like agent harness。 |
 | [shareAI-lab/claw0](https://github.com/shareAI-lab/claw0) | 从 0 到 1 学 OpenClaw-like gateway，10 个渐进章节覆盖 agent loop 到 concurrency。 |
 | [openclaw/openclaw](https://github.com/openclaw/openclaw) | 研究本地个人 agent、skills、长运行任务、系统工具和权限边界。 |

--- a/index.html
+++ b/index.html
@@ -513,7 +513,7 @@ const resourcesData = {
   projectMap: {
     title:'项目地图',
     rows:[
-      ['Build From Scratch','<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">learn-claude-code</a>, <a href="https://github.com/shareAI-lab/claw0" target="_blank">claw0</a>, <a href="https://github.com/datawhalechina/hello-agents" target="_blank">hello-agents</a>','agent loop、tool registry、session、context compaction、gateway、trace、subagents。'],
+      ['Build From Scratch','<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">learn-claude-code</a>, <a href="https://github.com/shareAI-lab/claw0" target="_blank">claw0</a>, <a href="https://github.com/datawhalechina/hello-agents" target="_blank">hello-agents</a>, <a href="https://github.com/lasywolf/Learn-OpenClaw" target="_blank">Learn-OpenClaw</a>','agent loop、tool registry、session、context compaction、gateway、trace、subagents；Learn-OpenClaw 适合 9 小时速通五大模块。'],
       ['Personal / Always-On Agents','<a href="https://github.com/openclaw/openclaw" target="_blank">OpenClaw</a>, <a href="https://github.com/NousResearch/hermes-agent" target="_blank">Hermes Agent</a>, <a href="https://github.com/ttguy0707/CyberClaw" target="_blank">CyberClaw</a>','长运行、skills、记忆、消息入口、权限、安全审计。'],
       ['Coding Agents','<a href="https://code.claude.com/docs/en/overview" target="_blank">Claude Code</a>, <a href="https://github.com/openai/codex" target="_blank">OpenAI Codex</a>, <a href="https://github.com/opencode-ai/opencode" target="_blank">OpenCode</a>, <a href="https://github.com/All-Hands-AI/OpenHands" target="_blank">OpenHands</a>, <a href="https://github.com/SWE-agent/SWE-agent" target="_blank">SWE-agent</a>, <a href="https://github.com/earendil-works/pi" target="_blank">pi</a>','真实代码库编辑、shell、测试、sandbox、PR 工作流。'],
       ['Agent Harness / SuperAgent Runtime','<a href="https://github.com/bytedance/deer-flow" target="_blank">DeerFlow</a>, <a href="https://langchain-ai.github.io/langgraph/" target="_blank">LangGraph</a>','长任务执行、sandbox、memory、skills、subagents、message gateway、trace。'],
@@ -581,6 +581,7 @@ const resourcesData = {
     title:'GitHub 仓库',
     rows:[
       ['<a href="https://github.com/datawhalechina/hello-agents" target="_blank">datawhalechina/hello-agents</a>','中文智能体系统教程，从零开始构建智能体。'],
+      ['<a href="https://github.com/lasywolf/Learn-OpenClaw" target="_blank">lasywolf/Learn-OpenClaw</a>','面向零基础/求职的 Agent 速通教程，9 小时覆盖 Node→RAG→Tool→Memory→Multi-Agent 五大模块。'],
       ['<a href="https://github.com/shareAI-lab/learn-claude-code" target="_blank">shareAI-lab/learn-claude-code</a>','Bash is all you need，从 0 到 1 学 Claude Code-like agent harness。'],
       ['<a href="https://github.com/shareAI-lab/claw0" target="_blank">shareAI-lab/claw0</a>','从 0 到 1 学 OpenClaw-like gateway，10 个渐进章节覆盖 agent loop 到 concurrency。'],
       ['<a href="https://github.com/openclaw/openclaw" target="_blank">openclaw/openclaw</a>','研究本地个人 agent、skills、长运行任务、系统工具和权限边界。'],


### PR DESCRIPTION
## Summary

Add [Learn-OpenClaw](https://github.com/lasywolf/Learn-OpenClaw) to the curated resources.

Learn-OpenClaw is a 9-hour Agent crash course (⭐448) covering:
- Node/Workflow → RAG → Tool/MCP/Skill → Memory → Multi-Agent
- Core `node.py` under 60 lines
- Designed for zero-basis learners and job seekers

### Changes
- **Project Map** (Build From Scratch): Added alongside learn-claude-code, claw0, hello-agents
- **GitHub Repositories**: Added `lasywolf/Learn-OpenClaw` entry
- Sync `index.html` with `README.md`